### PR TITLE
Add epel_class parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,7 +13,7 @@
 class ius (
 
   $ius_mirrorlist                       = $ius::params::ius_mirrorlist,
-  $ius_baseurl        = $ius::params::ius_baseurl,
+  $ius_baseurl                          = $ius::params::ius_baseurl,
   $ius_failovermethod                   = $ius::params::ius_failovermethod,
   $ius_proxy                            = $ius::params::ius_proxy,
   $ius_enabled                          = $ius::params::ius_enabled,
@@ -39,7 +39,7 @@ class ius (
   $ius_archive_gpgcheck                 = $ius::params::ius_archive_gpgcheck,
   $ius_archive_debuginfo_mirrorlist     = $ius::params::ius_archive_debuginfo_mirrorlist,
   $ius_archive_debuginfo_baseurl        = $ius::params::ius_archive_debuginfo_baseurl,
-  $ius_archive_debuginfo_failovermethod  = $ius::params::ius_archive_debuginfo_failovermethod,
+  $ius_archive_debuginfo_failovermethod = $ius::params::ius_archive_debuginfo_failovermethod,
   $ius_archive_debuginfo_proxy          = $ius::params::ius_archive_debuginfo_proxy,
   $ius_archive_debuginfo_enabled        = $ius::params::ius_archive_debuginfo_enabled,
   $ius_archive_debuginfo_gpgcheck       = $ius::params::ius_archive_debuginfo_gpgcheck,
@@ -67,7 +67,7 @@ class ius (
   $ius_dev_source_failovermethod        = $ius::params::ius_dev_source_failovermethod,
   $ius_dev_source_proxy                 = $ius::params::ius_dev_source_proxy,
   $ius_dev_source_enabled               = $ius::params::ius_dev_source_enabled,
-  $ius_dev_source_gpgcheck               = $ius::params::ius_dev_source_gpgcheck,
+  $ius_dev_source_gpgcheck              = $ius::params::ius_dev_source_gpgcheck,
 
   $ius_testing_mirrorlist               = $ius::params::ius_testing_mirrorlist,
   $ius_testing_baseurl                  = $ius::params::ius_testing_baseurl,
@@ -86,13 +86,15 @@ class ius (
   $ius_testing_source_failovermethod    = $ius::params::ius_testing_source_failovermethod,
   $ius_testing_source_proxy             = $ius::params::ius_testing_source_proxy,
   $ius_testing_source_enabled           = $ius::params::ius_testing_source_enabled,
-  $ius_testing_source_gpgcheck    = $ius::params::ius_testing_source_gpgcheck,
+  $ius_testing_source_gpgcheck          = $ius::params::ius_testing_source_gpgcheck,
+
+  $epel_class                           = $ius::params::epel_class,
 
 ) inherits ius::params {
 
   if $::osfamily == 'RedHat' and $::operatingsystem =~ /RedHat|CentOS/ {
     
-    include ::epel
+    include $epel_class
 
     yumrepo { 'ius':
       baseurl        => $ius_baseurl,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,12 +19,12 @@ class ius::params {
     }
   }
 
-  $ius_mirrorlist      = "http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-${ius_os}${::operatingsystemmajrelease}&arch=\$basearch"
-  $ius_baseurl        = 'absent'
-  $ius_failovermethod       = 'priority'
-  $ius_proxy         = $proxy
-  $ius_enabled         = '1'
-  $ius_gpgcheck       = '1'
+  $ius_mirrorlist                       = "http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-${ius_os}${::operatingsystemmajrelease}&arch=\$basearch"
+  $ius_baseurl                          = 'absent'
+  $ius_failovermethod                   = 'priority'
+  $ius_proxy                            = $proxy
+  $ius_enabled                          = '1'
+  $ius_gpgcheck                         = '1'
   $ius_debuginfo_mirrorlist             = "http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-${ius_os}${::operatingsystemmajrelease}-debuginfo&arch=\$basearch"
   $ius_debuginfo_baseurl                = 'absent'
   $ius_debuginfo_failovermethod         = 'priority'
@@ -46,7 +46,7 @@ class ius::params {
   $ius_archive_gpgcheck                 = '1'
   $ius_archive_debuginfo_mirrorlist     = "http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-${ius_os}${::operatingsystemmajrelease}-archive-debuginfo&arch=\$basearch"
   $ius_archive_debuginfo_baseurl        = 'absent'
-  $ius_archive_debuginfo_failovermethod  = 'priority'
+  $ius_archive_debuginfo_failovermethod = 'priority'
   $ius_archive_debuginfo_proxy          = $proxy
   $ius_archive_debuginfo_enabled        = '0'
   $ius_archive_debuginfo_gpgcheck       = '1'
@@ -55,7 +55,7 @@ class ius::params {
   $ius_archive_source_failovermethod    = 'priority'
   $ius_archive_source_proxy             = $proxy
   $ius_archive_source_enabled           = '0'
-  $ius_archive_source_gpgcheck           = '1'
+  $ius_archive_source_gpgcheck          = '1'
 
   $ius_dev_mirrorlist                 = "http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-${ius_os}${::operatingsystemmajrelease}-dev&arch=\$basearch"
   $ius_dev_baseurl                    = 'absent'
@@ -74,7 +74,7 @@ class ius::params {
   $ius_dev_source_failovermethod      = 'priority'
   $ius_dev_source_proxy               = $proxy
   $ius_dev_source_enabled             = '0'
-  $ius_dev_source_gpgcheck           = '1'
+  $ius_dev_source_gpgcheck            = '1'
 
   $ius_testing_mirrorlist               = "http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-${ius_os}${::operatingsystemmajrelease}-testing&arch=\$basearch"
   $ius_testing_baseurl                  = 'absent'
@@ -93,6 +93,8 @@ class ius::params {
   $ius_testing_source_failovermethod    = 'priority'
   $ius_testing_source_proxy             = $proxy
   $ius_testing_source_enabled           = '0'
-  $ius_testing_source_gpgcheck           = '1'
+  $ius_testing_source_gpgcheck          = '1'
+
+  $epel_class                           = ::epel
 
 }


### PR DESCRIPTION
Allow specifying your epel class.
I have epel class configured, but it's :: yum::repo::epel
This change allowed me to specify other class instead of ::epel

Also some indentation fixes included.